### PR TITLE
Install correct version of Hugo on `make install`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .vscode
 
+bin/*
+!bin/.gitkeep
 node_modules/
 public/
 tmp/
-themes/material/original/
 
 # Generated source files
 content/reference/pkg/*/


### PR DESCRIPTION
We've had lots of problems get building right because this site uses a more up-to-date version of Hugo than the rest of the IPFS sites. This attempts to fix that by just having make download and install the correct one locally.

I am *not* very good a `make`, so if other folks have better approaches, feel free to recommend changes.