### PR TITLE
docs: link to IPFS Addressing in Web Browsers Memo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -137,6 +137,10 @@ parent = "guides"
 name = "Transferring a File"
 url = "https://github.com/ipfs/go-ipfs/blob/master/docs/file-transfer.md"
 [[menu.guides]]
+parent = "guides"
+name = "Addressing in Browsers"
+url = "https://github.com/ipfs/in-web-browsers/blob/master/ADDRESSING.md"
+[[menu.guides]]
 parent = "examples"
 name = "js-ipfs Examples"
 url = "https://github.com/ipfs/js-ipfs/tree/master/examples"


### PR DESCRIPTION
This PR adds a link in the _Guides_ section, which is a first step in addressing (ha) https://github.com/ipfs/docs/issues/91. 
> ![2018-09-23--22-28-11](https://user-images.githubusercontent.com/157609/45932864-83f08880-bf83-11e8-9195-783bd441e28c.png)


See my long-term plan in https://github.com/ipfs/docs/issues/91#issuecomment-423851456

