### PR TITLE
feat: link to ProtoSchool tutorials

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,14 +132,22 @@ weight = 4
 parent = "guides"
 name = "Replicating Large Datasets"
 url = "https://github.com/ipfs/archives/tree/master/tutorials/replicating-large-datasets"
+weight = 3
 [[menu.guides]]
 parent = "guides"
 name = "Transferring a File"
 url = "https://github.com/ipfs/go-ipfs/blob/master/docs/file-transfer.md"
+weight = 2
 [[menu.guides]]
 parent = "guides"
 name = "Addressing in Browsers"
 url = "https://github.com/ipfs/in-web-browsers/blob/master/ADDRESSING.md"
+weight = 4
+[[menu.guides]]
+parent = "guides"
+name = "Interactive Tutorials"
+url = "https://proto.school/#/tutorials"
+weight = 5
 [[menu.guides]]
 parent = "examples"
 name = "js-ipfs Examples"
@@ -290,3 +298,7 @@ parent = "related"
 name = "IPLD"
 url = "https://ipld.io"
 weight = 3
+[[menu.community]]
+parent = "related"
+name = "ProtoSchool"
+url = "https://proto.school/"

--- a/content/_index.md
+++ b/content/_index.md
@@ -16,6 +16,7 @@ The guides section has an overview of major concepts in IPFS, guides, and exampl
 
 In particular, IPFS is a complex system that aims to change a lot of things about how we use the internet, so it naturally comes with a lot of new concepts. Check the [concepts](/guides/concepts) section to learn more about the major architectural pieces of IPFS and about terms and ideas associated with distributed file systems.
 
+If you prefer “hands-on” approach, [ProtoSchool](https://proto.school) will introduce you to decentralized web by writing code and solving challenges.
 
 ## Reference
 
@@ -59,6 +60,6 @@ If you are diving in to contribute new code, make sure you check both the [contr
 
 We’ve split out some of the major parts of IPFS into separate projects over time — while they’re still critical components of IPFS, they can be useful in a variety of other contexts, too. Check their individual sites for specific information and references:
 
-- [Libp2p](https://libp2p.io) manages all the peer-to-peer networking parts of IFPS.
+- [Libp2p](https://libp2p.io) manages all the peer-to-peer networking parts of IPFS.
 - [Multiformats](https://multiformats.io) is a variety of *self-describing* data formats.
 - [IPLD](https://ipld.io) is a set of tools for describing links between content-addressed data, like IPFS files, Git commits, or Ethereum blocks.

--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,7 @@ The guides section has an overview of major concepts in IPFS, guides, and exampl
 
 In particular, IPFS is a complex system that aims to change a lot of things about how we use the internet, so it naturally comes with a lot of new concepts. Check the [concepts](/guides/concepts) section to learn more about the major architectural pieces of IPFS and about terms and ideas associated with distributed file systems.
 
-If you prefer “hands-on” approach, [ProtoSchool](https://proto.school) will introduce you to decentralized web by writing code and solving challenges.
+If you prefer a hands-on approach, try out the interactive tutorials at [ProtoSchool](https://proto.school), where you can learn about the decentralized web by solving code challenges.
 
 ## Reference
 

--- a/content/guides/examples/_index.md
+++ b/content/guides/examples/_index.md
@@ -7,4 +7,11 @@ menu:
         weight: 2
 ---
 
+<div class="alert alert-info">
+Our interactive tutorials help you learn about the the decentralized web by writing code and solving challenges:
+<a class="button button-primary" href="https://proto.school/#/tutorials" role="button" target="_blank">
+  Open Tutorials at ProtoSchool &nbsp;&nbsp;<i class="fa fa-external-link-square-alt"></i>
+</a>
+</div>
+
 These are a few examples that cover various ways to use IPFS.


### PR DESCRIPTION
This change adds links to ProtoSchool in various places with intention to improve its discoverability.

> ![2019-02-05--17-07-39](https://user-images.githubusercontent.com/157609/52286480-94206780-2968-11e9-866b-d3d0d1ee75ad.png)


cc @ipfs/docs @terichadbourne