### PR TITLE
docs: add IPNS example from js-ipfs specs

### DIFF
--- a/content/guides/concepts/ipns.md
+++ b/content/guides/concepts/ipns.md
@@ -19,9 +19,9 @@ IPNS is not the only way to create mutable addresses on IPFS. You can also use [
 
 **Example:**
 
-Imagine you want to publish your website under IPFS. You can use the [Files API](/guides/concepts/mfs) to publish your static website and then you'll get a multihash you can link to. But when you need to make a change, a problem arises: you get a new multihash because you now have a different content. And it is not possible for you to be always giving others the new address.
+Imagine you want to publish your website under IPFS. You can use the [Files API](/guides/concepts/mfs) to publish your static website and then you'll get a CID you can link to. But when you need to make a change, a problem arises: you get a new CID because you now have a different content. And it is not possible for you to be always giving others the new address.
 
-Here's where the Name API comes in handy. With it, you can use one static multihash for your website under IPNS (InterPlanetary Name Service). This way, you can have one single multihash poiting to the newest version of your website.
+Here's where the Name API comes in handy. With it, you can create a single, stable IPNS address that points to the CID for the latest version of your website.
 
 ```JavaScript
 // The address of your files.
@@ -35,4 +35,4 @@ ipfs.name.publish(addr, function (err, res) {
 })
 ```
 
-This way, you can republish a new version of your website under the same address. By default, `ipfs.name.publish` will use the Peer ID.
+In the same way, you can republish a new version of your website under the same address. By default, `ipfs.name.publish` will use the Peer ID.

--- a/content/guides/concepts/ipns.md
+++ b/content/guides/concepts/ipns.md
@@ -15,6 +15,24 @@ When looking up an IPNS address, use the `/ipns/` prefix:
 /ipns/QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd
 ```
 
-<!-- TODO: more description of creating and publishing a name -->
-
 IPNS is not the only way to create mutable addresses on IPFS. You can also use [DNSLink](/guides/concepts/dnslink) (which is currently much faster than IPNS and also uses more readable names). Other community members are exploring ways to use blockchains to store common name records.
+
+**Example:**
+
+Imagine you want to publish your website under IPFS. You can use the [Files API](/guides/concepts/mfs) to publish your static website and then you'll get a multihash you can link to. But when you need to make a change, a problem arises: you get a new multihash because you now have a different content. And it is not possible for you to be always giving others the new address.
+
+Here's where the Name API comes in handy. With it, you can use one static multihash for your website under IPNS (InterPlanetary Name Service). This way, you can have one single multihash poiting to the newest version of your website.
+
+```JavaScript
+// The address of your files.
+const addr = '/ipfs/QmbezGequPwcsWo8UL4wDF6a8hYwM1hmbzYv2mnKkEWaUp'
+
+ipfs.name.publish(addr, function (err, res) {
+    // You now receive a res which contains two fields:
+    //   - name: the name under which the content was published.
+    //   - value: the "real" address to which Name points.
+    console.log(`https://gateway.ipfs.io/ipns/${res.name}`)
+})
+```
+
+This way, you can republish a new version of your website under the same address. By default, `ipfs.name.publish` will use the Peer ID.


### PR DESCRIPTION
I found the IPNS example in https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/NAME.md#namepublish to be really helpful as a real world use case.