### PR TITLE
Add doNotTrack aware google analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://docs.ipfs.io"
 relativeURLs = true
 languageCode = "en"
 DefaultContentLanguage = "en"
+googleAnalytics = "UA-96910779-6"
 
 title = "IPFS Documentation"
 

--- a/config.toml
+++ b/config.toml
@@ -2,11 +2,14 @@ baseURL = "https://docs.ipfs.io"
 relativeURLs = true
 languageCode = "en"
 DefaultContentLanguage = "en"
+title = "IPFS Documentation"
+staticDir = ["static", "build"]
 googleAnalytics = "UA-96910779-6"
 
-title = "IPFS Documentation"
-
-staticDir = ["static", "build"]
+[privacy]
+  [privacy.googleAnalytics]
+    anonymizeIP = true
+    respectDoNotTrack = true
 
 [blackfriday]
 hrefTargetBlank = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,13 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="stylesheet" href="{{ relURL .Site.BaseURL }}assets/main.css">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96910779-6"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-96910779-6');
+    </script>
   </head>
   <body data-md-color-primary="indigo" data-md-color-accent="indigo">
     <div class="wrapper">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,13 +17,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="stylesheet" href="{{ relURL .Site.BaseURL }}assets/main.css">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96910779-6"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96910779-6');
-    </script>
+    {{ template "_internal/google_analytics_async.html" . }}
   </head>
   <body data-md-color-primary="indigo" data-md-color-accent="indigo">
     <div class="wrapper">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="stylesheet" href="{{ relURL .Site.BaseURL }}assets/main.css">
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
   </head>
   <body data-md-color-primary="indigo" data-md-color-accent="indigo">
     <div class="wrapper">


### PR DESCRIPTION
The internal hugo ga template in versions > v0.41 has support for doNotTrack and ga IP anonymisation, so use that instead of rolling our own.