### PR TITLE
dig for TXT, not TEXT

### DIFF
--- a/content/guides/examples/websites.md
+++ b/content/guides/examples/websites.md
@@ -49,7 +49,7 @@ Create a DNS TXT record ([DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/
 Once you've created that record, and it has propagated you should be able to find it.
 
 ```bash
-$ dig +noall +answer TEXT your.domain
+$ dig +noall +answer TXT your.domain
 your.domain.            60      IN      TXT     "dnslink=/ipfs/$SITE_CID"
 ```
 Now you can view your site at `http://localhost:8080/ipns/your.domain`. 


### PR DESCRIPTION
As far as I can tell, we're only creating a TXT record here, and dig will never return the dnslink when asked for a TEXT record.