### PR TITLE
fix: bring back deploy from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:1.1
+      - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: docs.ipfs.io
           BUILD_DIR: public


### PR DESCRIPTION
- update ipfs-dns-deploy to latest so it works with cluster 0.10

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>