### PR TITLE
Update IPFS website tutorial

### DIFF
--- a/content/guides/examples/websites.md
+++ b/content/guides/examples/websites.md
@@ -4,6 +4,8 @@ title: IPFS for Websites
 
 ### A short guide to hosting your site on IPFS
 
+***Note:** [@agentofuser](https://github.com/agentofuser/)'s "Complete Beginner's Guide to Deploying Your First Static Website to IPFS" (see the [writeup](https://interplanetarygatsby.com/ipfs-deploy/) and [repo](https://github.com/agentofuser/ipfs-deploy)) is another useful resource for learning more about hosting your site on IPFS.*
+
 #### Create your site
 
 Assume you have a static website in a directory `mysite`. 

--- a/content/guides/examples/websites.md
+++ b/content/guides/examples/websites.md
@@ -8,7 +8,7 @@ title: IPFS for Websites
 
 Assume you have a static website in a directory `mysite`. 
 
-In order to publish it as a site, make sure your ipfs daemon is running:
+In order to publish it as a site, [install ipfs](https://docs.ipfs.io/guides/guides/install/) and make sure your ipfs daemon is running:
 
 ```bash
 $ ipfs daemon
@@ -55,6 +55,8 @@ your.domain.            60      IN      TXT     "dnslink=/ipfs/$SITE_CID"
 Now you can view your site at `http://localhost:8080/ipns/your.domain`. 
 
 You can also try this on the gateway at `http://gateway.ipfs.io/ipns/your.domain`.
+
+More questions about DNSLink? Check out the website for tutorials, examples, and FAQ: http://dnslink.io/
 
 #### Using the Interplanetary Naming System
 


### PR DESCRIPTION
I was about to send this to someone wondering how to easily add their website to IPFS and realized it hadn't been updated recently and might no longer have the recommended path/steps for adding a website to IPFS. @aschmahmann / @hugomrdias - are the IPNS/dnslink instructions here still accurate? @olizilla - any other caveats or other instructions we should give someone trying to deploy a website to ipfs about what to do if these instructions aren't a good fit for their needs?