### PR TITLE
Basic Examples findability

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,7 @@ Head over to the [introduction](/introduction) section to learn about the basics
 
 ## Guides
 
-IPFS is a complex system that hopes to change how we use the internet, so it comes with many new concepts. The guides section has an overview of major [concepts](/guides/concepts) in IPFS (including terms and ideas associated with distributed file systems generally), guides for specific IPFS use cases, and example projects demonstrating various ways to use the IPFS ecosystem.
+IPFS is a complex system that hopes to change how we use the internet, so it comes with many new concepts. The guides section has an overview of major [concepts](/guides/concepts) in IPFS (including terms and ideas associated with distributed file systems generally), guides for specific IPFS use cases, and [basic examples](/guides/examples) demonstrating various ways to use the IPFS ecosystem.
 
 If you prefer a hands-on approach, try out the interactive tutorials at [ProtoSchool](https://proto.school). You can learn about the decentralized web by solving code challenges.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -11,19 +11,21 @@ Here's an overview of what you'll find in our documentation:
 
 Head over to the [introduction](/introduction) section to learn about the basics of IPFS. There are also instructions on how to install IPFS, and tips on basic IPFS usage.
 
-
 ## Guides
 
-IPFS is a complex system that hopes to change how we use the internet, so it comes with many new concepts. The guides section has an overview of major [concepts](/guides/concepts) in IPFS (including terms and ideas associated with distributed file systems generally), guides for specific IPFS use cases, and [basic examples](/guides/examples) demonstrating various ways to use the IPFS ecosystem.
+IPFS is a complex system that hopes to change how we use the internet, so it comes with many new concepts. The guides section has an overview of major [concepts](/guides/concepts) in IPFS (including terms and ideas associated with distributed file systems generally), and guides for specific IPFS use cases. Some [basic examples](/guides/examples) of ways to use the IPFS ecosystem, including:
 
-If you prefer a hands-on approach, try out the interactive tutorials at [ProtoSchool](https://proto.school). You can learn about the decentralized web by solving code challenges.
+* A simple [how-to on pinning](/guides/examples/pinning)
+* Instructions for [making your own IPFS service](/guides/examples/api/service/readme)
+* A guide to [hosting your website](/guides/examples/websites)
+
+For detailed guidance on select topics, try out the interactive tutorials at [ProtoSchool](https://proto.school). You can learn about the decentralized web by solving code challenges.
 
 ## Reference
 
 ### Commands & API
 
 If you are using IPFS via the [command line](/reference/api/cli) or [interacting with a running IPFS node](/reference/api/http) programmatically, you’ll use IPFS’s commands API. It’s implemented in both the Go and JavaScript versions of IPFS.
-
 
 ### Go & JavaScript Implementations
 


### PR DESCRIPTION
Proposing this to close #216, "Basics Issues are Hard to Find."
_(Not to be confused with this [classic tale](http://xroads.virginia.edu/~drbr/goodman.html))_

Also posited in the issue was a parent / child subnav scheme, but i wonder whether that would really net us much of a usability lift.

If we added all of the subtopics to the sidenav by default, that would make the nav extremely long. But if we expanded the menu only on click, then it would essentially duplicate the list contained on the basic examples index page itself:

![image](https://user-images.githubusercontent.com/9259185/63059291-a1d51d80-beb4-11e9-9dc6-60c8aec15fa8.png)

Neither approach seems to net us much imo, but what do you think? Having the expanded nav _would_ make it visible while users explored the various subtopics in that section. If that benefit alone is deemed a sufficient bonus, we can go ahead and add the subnav.

#216 also suggests that some of the [example topics](https://docs.ipfs.io/guides/examples/) might be good protoschool tutorials fodder. cc @terichadbourne if interested :) 