### PR TITLE
Quick type color and alert box fixes

### DIFF
--- a/src/styles/components/alert.less
+++ b/src/styles/components/alert.less
@@ -1,7 +1,6 @@
 // Quick and dirty bootstrap-style "alert" box from old website.
 // This supports markup in already-existing docs. We may want to change it.
 .alert {
-  border: 1px solid #f3f3f3;
   box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
   margin: 1em 0;
   padding: 1em;
@@ -12,11 +11,13 @@
 .alert > *:last-child { margin-bottom: 0; }
 
 .alert-info {
-  border-left: 4px solid @colors-aqua-muted;
+  border: 1px solid @accent-teal;
+  border-left: 4px solid @accent-teal;
 }
 
 .alert-warning {
-  border-left: 4px solid @colors-yellow-muted;
+  border: 1px solid @accent-gold;
+  border-left: 4px solid @accent-gold;
 }
 
 .alert + p {

--- a/src/styles/components/alert.less
+++ b/src/styles/components/alert.less
@@ -1,7 +1,6 @@
 // Quick and dirty bootstrap-style "alert" box from old website.
 // This supports markup in already-existing docs. We may want to change it.
 .alert {
-  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.1);
   margin: 1em 0;
   padding: 1em;
 }
@@ -11,12 +10,12 @@
 .alert > *:last-child { margin-bottom: 0; }
 
 .alert-info {
-  border: 1px solid @accent-teal;
+  border: 2px solid @accent-teal;
   border-left: 4px solid @accent-teal;
 }
 
 .alert-warning {
-  border: 1px solid @accent-gold;
+  border: 2px solid @accent-gold;
   border-left: 4px solid @accent-gold;
 }
 

--- a/src/styles/components/footer.less
+++ b/src/styles/components/footer.less
@@ -7,7 +7,7 @@
 
   p {
     margin: 0 0 0.5em;
-    font-size: 12px;
+    font-size: .875rem;
   }
 
   .social-link {

--- a/src/styles/components/footer.less
+++ b/src/styles/components/footer.less
@@ -7,6 +7,7 @@
 
   p {
     margin: 0 0 0.5em;
+    font-size: 12px;
   }
 
   .social-link {

--- a/src/styles/components/sidebar.less
+++ b/src/styles/components/sidebar.less
@@ -49,7 +49,7 @@
 
 .sidebar-nav--link {
   color: inherit;
-  // margin-top: .25em;
+  text-decoration: none;
   transition: color 0.125s;
 
   &.active,
@@ -60,6 +60,7 @@
   &:focus,
   &:hover {
     color: @link-highlight-color;
+    border-bottom: none;
   }
 }
 

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -2,9 +2,18 @@
 @import (inline) "./inter-ui.css";
 @import "./constants";
 
-// TODO: figure out a good standard color for this?
-@link-color: #3f51b5;
-@link-highlight-color: #536dfe;
+@ipfs-green: #138dc8;
+@brand-blue: #083b54;
+@ipfs-dark-grey: #34373f;
+@brand-teal: #6acad1;
+@accent-teal: #469ea2;
+@accent-red: #f05135;
+@accent-gold: #f59223;
+
+@text-color: @ipfs-dark-grey;
+@heading-color: @brand-blue;
+@link-color: lighten(@brand-blue, 25%);
+@link-highlight-color: lighten(@brand-blue, 35%);
 
 @minimum-layout-width: 50rem;
 @narrow-layout-width: (@minimum-layout-width - 0.001rem);
@@ -14,12 +23,13 @@
 }
 
 body {
-  color: #333;
+  color: @text-color;
   font-family: @fonts-sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
 h1, h2 {
+  color: @heading-color;
   font-family: @fonts-montserrat;
   font-weight: 700;
 }
@@ -29,18 +39,20 @@ h3, h4, h5, h6 {
   font-weight: 600;
 }
 
-code, kbd, pre, samp, var {
-  font-family: @fonts-monospace;
-}
-
-a {
+p a, h2 a, h3 a, h4 a, h5 a, h6 a, aside a, table a, li a {
   color: @link-color;
   text-decoration: none;
-  -webkit-text-decoration-skip: objects;
+  transition: color 0.125s;
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: @link-highlight-color;
+    border-bottom: 1px solid @link-highlight-color;
   }
+}
+
+code, kbd, pre, samp, var {
+  font-family: @fonts-monospace;
 }
 
 a, button, input, label {


### PR DESCRIPTION
Hairball quickfix PR that makes it so I can find links and read text on our docs pages. I was going a leeeetle crazy with the blue-on-black link situation.

Included in this PR, today only, for the low low price of three poodles and a pibble:

- Replace most type colors with brand colors from ipfs.io.
- Make links findable/readable (hopefully) (tho not accessible -- they need an indicator that *isn't* color, but this quickfix is no worse than it was)
- Sharpen alert boxes
- Smallify text in footer because it was like YELLING COPYRIGHT when you scrolled to the bottom of an article 

## Current
<img width="1130" alt="Screenshot 2019-08-18 23 29 31" src="https://user-images.githubusercontent.com/4827522/63243779-66b64f80-c210-11e9-81bc-cfd0e66a083e.png">

## This PR
<img width="1130" alt="Screenshot 2019-08-18 23 29 47" src="https://user-images.githubusercontent.com/4827522/63243765-5ef6ab00-c210-11e9-8bb7-7f47c0bb399e.png">