### PR TITLE
feat: was this helpful?

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="icon" type="image/x-icon" href="{{ with .Site.Params.favicon }}{{ . | absURL }}{{ else }}{{ "images/favicon.ico" | absURL }}{{ end }}">
     <link rel="stylesheet" href="{{ relURL .Site.BaseURL }}assets/main.css">
-    {{ template "_internal/google_analytics.html" . }}
+    {{ template "_internal/google_analytics_async.html" . }}
   </head>
   <body data-md-color-primary="indigo" data-md-color-accent="indigo">
     <div class="wrapper">

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,0 +1,9 @@
+<div class="feedback">
+  <h3>Did you find this helpful?</h3>
+  <div class="feedback--actions">
+    <button title="Helpful">Yes</button><button title="Not Helpful">No</button>
+  </div>
+  <div class="feedback--result">
+    <p>Thank you for the feedback.</p>
+  </div>
+</div>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,5 +1,5 @@
 <div class="feedback">
-  <h3>Did you find this helpful?</h3>
+  <h3>Was this document helpful?</h3>
   <div class="feedback--actions">
     <button title="Helpful">Yes</button><button title="Not Helpful">No</button>
   </div>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,5 +1,5 @@
 <div class="feedback">
-  <h3>Was this document helpful?</h3>
+  <h3>Was this information helpful?</h3>
   <div class="feedback--actions">
     <button title="Helpful">Yes</button><button title="Not Helpful">No</button>
   </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,4 @@
+{{ partial "feedback" . }}
 <footer class="page-footer">
   <div class="page-footer--copyright">
     <p class="md-footer-copyright__highlight">

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,7 +307,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1175,6 +1176,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1633,7 +1635,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "deps-sort": {
       "version": "2.0.0",
@@ -2362,7 +2365,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2563,7 +2567,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2584,12 +2589,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2604,17 +2611,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2731,7 +2741,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2743,6 +2754,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2757,6 +2769,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2764,12 +2777,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2788,6 +2803,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2868,7 +2884,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2880,6 +2897,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2965,7 +2983,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3001,6 +3020,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3020,6 +3040,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3063,12 +3084,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3843,7 +3866,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -4160,6 +4184,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -6095,7 +6120,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "browserify": "^16.2.3",
-    "hugo-bin": "0.33.0",
+    "hugo-bin": "0.45.2",
     "less": "^3.9.0",
     "less-plugin-autoprefix": "^2.0.0",
     "less-plugin-clean-css": "^1.5.1",

--- a/src/js/feedback.js
+++ b/src/js/feedback.js
@@ -1,4 +1,5 @@
 module.exports = function () {
+  var ctx = 'feedback'
   function sendFeedback (el) {
     if (!window.ga) return
     window.ga('send', 'event', {
@@ -8,15 +9,15 @@ module.exports = function () {
     })
   }
   document.addEventListener('DOMContentLoaded', function () {
-    const feedbackEl = document.querySelector('.feedback')
+    const feedbackEl = document.querySelector('.' + ctx)
     feedbackEl.querySelectorAll('button').forEach(function (el) {
       el.addEventListener('click', function () {
         feedbackEl
-          .querySelector('.feedback--actions')
-          .classList.add('feedback--hide')
+          .querySelector('.' + ctx + '--actions')
+          .classList.add(ctx + '--hide')
         feedbackEl
-          .querySelector('.feedback--result')
-          .classList.add('feedback--show')
+          .querySelector('.' + ctx + '--result')
+          .classList.add(ctx + '--show')
         sendFeedback(el)
       })
     })

--- a/src/js/feedback.js
+++ b/src/js/feedback.js
@@ -1,0 +1,24 @@
+module.exports = function () {
+  function sendFeedback (event) {
+    if (!window.ga) return
+    window.ga('send', 'event', {
+      eventCategory: 'helpful',
+      eventAction: 'click',
+      eventLabel: window.location.href
+    })
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    const feedbackEl = document.querySelector('.feedback')
+    feedbackEl.querySelectorAll('button').forEach(function (el) {
+      el.addEventListener('click', function () {
+        feedbackEl
+          .querySelector('.feedback--actions')
+          .classList.add('feedback--hide')
+        feedbackEl
+          .querySelector('.feedback--result')
+          .classList.add('feedback--show')
+        console.log(window.location.href)
+      })
+    })
+  })
+}

--- a/src/js/feedback.js
+++ b/src/js/feedback.js
@@ -1,10 +1,10 @@
 module.exports = function () {
-  function sendFeedback (event) {
+  function sendFeedback (el) {
     if (!window.ga) return
     window.ga('send', 'event', {
-      eventCategory: 'helpful',
+      eventCategory: el.title.toLowerCase(),
       eventAction: 'click',
-      eventLabel: window.location.href
+      eventLabel: window.location.pathname
     })
   }
   document.addEventListener('DOMContentLoaded', function () {
@@ -17,7 +17,7 @@ module.exports = function () {
         feedbackEl
           .querySelector('.feedback--result')
           .classList.add('feedback--show')
-        console.log(window.location.href)
+        sendFeedback(el)
       })
     })
   })

--- a/src/js/feedback.js
+++ b/src/js/feedback.js
@@ -4,7 +4,7 @@ module.exports = function () {
     window.ga('send', 'event', {
       eventCategory: el.title.toLowerCase(),
       eventAction: 'click',
-      eventLabel: window.location.pathname
+      eventLabel: window.location.href
     })
   }
   document.addEventListener('DOMContentLoaded', function () {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,5 @@
 const Menu = require('./menu')
+const Feedback = require('./feedback')
 
 function setup () {
   document.documentElement.classList.add('interactive')
@@ -10,11 +11,14 @@ function setup () {
       button.addEventListener('click', event => menu.show())
     }
   }
+  const feedbackElement = document.querySelector('.feedback')
+  if (feedbackElement) {
+    Feedback()
+  }
 }
 
-const requiredFeatures = document.querySelector &&
-  document.body.classList &&
-  document.body.contains
+const requiredFeatures =
+  document.querySelector && document.body.classList && document.body.contains
 
 if (requiredFeatures) {
   setup()

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -8,6 +8,7 @@
 }
 
 .feedback {
+  margin: 2em 0;
   &--result {
     display: none;
   }
@@ -19,7 +20,7 @@
     display: none;
   }
   button {
-    border: 1px solid;
+    border: @link-highlight-color 1px solid;
     background-color: transparent;
     margin-right: 10px;
     min-width: 100px;
@@ -27,9 +28,11 @@
     font-family: @fonts-montserrat;
     font-weight: 700;
     font-size: 1.1em;
+    line-height: 2em;
     cursor: pointer;
     &:hover {
-      background-color: @accent-teal;
+      background-color: @link-highlight-color;
+      color: white;
     }
   }
 }

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -8,6 +8,9 @@
 }
 
 .feedback {
+  h3 {
+    color: @heading-color;
+  }
   margin: 2em 0;
   &--result {
     display: none;

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -22,6 +22,14 @@
   &--hide {
     display: none;
   }
+  &--result.feedback--show {
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    * {
+      margin: 0;
+    }
+  }
   button {
     border: @link-highlight-color 1px solid;
     background-color: transparent;

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -1,0 +1,35 @@
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.feedback {
+  &--result {
+    display: none;
+  }
+  &--show {
+    display: block;
+    animation: fadein 1s;
+  }
+  &--hide {
+    display: none;
+  }
+  button {
+    border: 1px solid;
+    background-color: transparent;
+    margin-right: 10px;
+    min-width: 100px;
+    color: @heading-color;
+    font-family: @fonts-montserrat;
+    font-weight: 700;
+    font-size: 1.1em;
+    cursor: pointer;
+    &:hover {
+      background-color: @accent-teal;
+    }
+  }
+}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -73,6 +73,7 @@ a, button, input, label {
 @import "./components/layout";
 @import "./components/header";
 @import "./components/footer";
+@import "./components/feedback";
 @import "./components/sidebar";
 @import "./components/article";
 @import "./components/alert";


### PR DESCRIPTION
This PR add a simple feedback mechanism to our documentation pages so we can begin to collect metrics on documents that may require attention.

__Tracked in GA as__:
+ event category: helpful/not helpful
+ event action: click
+ event label: current href

![2019-09-04 15 37 15](https://user-images.githubusercontent.com/106938/64264917-fc005600-cf29-11e9-8871-568a2990c63a.gif)

__Notes__:
+ This is a hotfix release so we can (and should) continue to improve this later on if we see usage.
+ It would be nice to also capture long-form comments as an additional dimension (we have up to 500 bytes that we can use on an events label for this)
+ We add one feedback form per page, so for the long single page documents such as the CLI and HTTP docs it won't provide a clear actionable picture.
+ This respects browser DNT settings, so if DNT is enabled no events will be collected.