### PR TITLE
Add gateway guide to nav

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,7 +55,7 @@ url = "https://github.com/ipfs/go-ipfs/blob/master/docs/file-transfer.md"
 weight = 2
 [[menu.guides]]
 parent = "guides"
-name = "Setting Up an IPFS Gateway"
+name = "Setting Up a Gateway"
 url = "https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md"
 weight = 3
 [[menu.guides]]

--- a/config.toml
+++ b/config.toml
@@ -55,9 +55,14 @@ url = "https://github.com/ipfs/go-ipfs/blob/master/docs/file-transfer.md"
 weight = 2
 [[menu.guides]]
 parent = "guides"
+name = "Setting Up an IPFS Gateway"
+url = "https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md"
+weight = 3
+[[menu.guides]]
+parent = "guides"
 name = "Replicating Large Datasets"
 url = "https://github.com/ipfs/archives/tree/master/tutorials/replicating-large-datasets"
-weight = 3
+weight = 4
 [[menu.guides]]
 parent = "guides"
 name = "Interactive Tutorials"


### PR DESCRIPTION
Added link to basic gateway guide as found by @daviddias in https://github.com/ipfs/go-ipfs/pull/6694#discussion_r330087275 -- understood this is a bit of a temporary band-aid, as gateway topics are covered in #273, but better than not having it in current docs site at all.