### PR TITLE
Make it clear what "the community section" means

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -37,7 +37,7 @@ While IPFS has two reference implementations (in Go and JavaScript), it is funda
 
 Get in touch with other members of the IPFS community who are building tools on top of IPFS or even helping to build IPFS itself! You can ask questions, discuss new ideas, or get support for problems at https://discuss.ipfs.io, but you can also [hop on IRC](/community/irc) for a quick chat.
 
-See the other links in the community section for more information about meetings, events, apps people are building, and more.
+See the other links in the community section of the navigation panel at left for more information about meetings, events, apps people are building, and more.
 
 Information about contributing to IPFS and about other software projects in the community are also hosted here.
 


### PR DESCRIPTION
I arrived at the community section of this documentation by clicking "Community" in the footer of the ipfs.io website. I actually assumed it was going to take me to a GitHub repo I've seen before (not that I enjoy that as a presentation mechanism) and wasn't expecting the docs site. 

I was trying to find links to all of the social channels (IRC, etc.) for someone who asked me where to discuss IPFS questions. When I got to the phrase "See the other links in the community section" I tried scrolling down within the page I was on but felt like I was already in the community section. The nav is so long that there was no hint of community on the portion of it in view, though it actually didn't occur to me to look there. ¯\_(ツ)_/¯ 

Is there a way to link someone to an anchor in the nav or do I just need to describe the process of scrolling in the nav until you find the links? Should they be duplicated in the content of the community section here?