### PR TITLE
Move "edit this page in GitHub" link to near feedback buttons per #305

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -245,15 +245,18 @@ weight = 90
 parent = "community"
 name = "Awesome IPFS"
 url = "https://awesome.ipfs.io/"
+weight = 91
 [[menu.community]]
 parent = "community"
 name = "Public Archives on IPFS"
 title = "A community project to host archives of valuable public data."
 url = "https://awesome.ipfs.io/datasets/"
+weight = 93
 [[menu.community]]
 parent="community"
-name = "FAQ"
+name = "Forum FAQ Archive"
 url = "https://discuss.ipfs.io/c/help/Old-FAQ"
+weight = 95
 
 [[menu.community]]
 identifier = "contribute"

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -7,7 +7,7 @@
   <div class="feedback--result">
     <p>Thank you for the feedback.</p>
   </div>
-  <p>
-    <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" class="edit-page-link">Edit this page in GitHub</a>
+  <p class="edit-page-link">
+    <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" target="_blank">Edit this page</a> in GitHub or <a href="https://github.com/ipfs/docs/issues/new?assignees=&labels=docs-ipfs&template=issue.md&title=Page%20Feedback%20-%20{{ .Page.Title }}" target="_blank">open an issue</a> 
   </p>
 </div>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -7,4 +7,7 @@
   <div class="feedback--result">
     <p>Thank you for the feedback.</p>
   </div>
+  <p>
+    <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" class="edit-page-link">Edit this page in GitHub</a>
+  </p>
 </div>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -7,7 +7,7 @@
   <div class="feedback--result">
     <p>Thank you for the feedback.</p>
   </div>
-  <p class="edit-page-link">
-    <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" target="_blank">Edit this page</a> in GitHub or <a href="https://github.com/ipfs/docs/issues/new?assignees=&labels=docs-ipfs&template=issue.md&title=Page%20Feedback%20-%20{{ .Page.Title }}" target="_blank">open an issue</a> 
+  <p class="feedback--edit-or-open">
+    <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" target="_blank">Edit this page</a> in GitHub or <a href="https://github.com/ipfs/docs/issues/new?assignees=&labels=docs-ipfs&template=issue.md&title=Page%20Feedback%20-%20{{ .Page.Title }}" target="_blank">open an issue</a>
   </p>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,9 +13,6 @@
       {{/* We temporarily removed the search functionality and therefore lunrjs.
         <a href="https://lunrjs.com">lunr.js</a>, */}}
     </p>
-    <p>
-      <a href="https://github.com/ipfs/docs/blob/master/content/{{ .File.Path }}" class="edit-page-link">Edit this page in GitHub</a>
-    </p>
   </div>
 
   <div class="page-footer--social">

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -47,3 +47,7 @@
     }
   }
 }
+
+.edit-page-link {
+  font-size: .875rem;
+}

--- a/src/styles/components/feedback.less
+++ b/src/styles/components/feedback.less
@@ -48,6 +48,6 @@
   }
 }
 
-.edit-page-link {
+.feedback--edit-or-open {
   font-size: .875rem;
 }


### PR DESCRIPTION
Per discussion in #305 ...
- Shifted the "edit this page in GitHub" link up next to the feedback buttons
- Added "or open an issue" link at the end that references the page title in the title of the newly-created issue

Also totally accidentally pushed a change in old FAQ sidebar link to "Forum FAQ Archive". Apologies for the topical mismatch in a single PR.

Closes #305 
(since implementation of those mockups in the beta site is happening in #306)