### PR TITLE
Closes link tag in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 <footer class="page-footer">
   <div class="page-footer--copyright">
     <p class="md-footer-copyright__highlight">
-      © <a href="//protocol.ai">Protocol Labs</a> | Except as noted, content licensed <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0
+      © <a href="//protocol.ai">Protocol Labs</a> | Except as noted, content licensed <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</a>
     </p>
     <p>
       Powered by


### PR DESCRIPTION
Creative Commons link tag in the footer wasn't closed, so the link spilled over onto "Powered by" on the following line.