### PR TITLE
fixed link for js examples

### DIFF
--- a/content/guides/examples/_index.md
+++ b/content/guides/examples/_index.md
@@ -10,5 +10,5 @@ Our interactive tutorials help you learn about the the decentralized web by writ
 
 Below are examples that cover various ways to use IPFS. If there's an example that doesn't appear below, but that you'd like to see, please [file an issue](https://github.com/ipfs/docs/issues/new/choose) in the IPFS docs GitHub repo and let us know more details!
 
-## [js-ipfs Examples](https://github.com/ipfs/js-ipfs/tree/master/examples) <i class="fa fa-external-link-square-alt"></i>
+## [js-ipfs Examples](https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs/examples) <i class="fa fa-external-link-square-alt"></i>
 A variety of examples to help you get started with js-ipfs in Node.js and in the browser. Every example has a specific purpose, and some incorporate a full tutorial that you can follow through, helping you expand your knowledge about IPFS and the distributed web in general.


### PR DESCRIPTION
The link for js example is showing 404 on github. change it to the correct link