### PR TITLE
Fix blog link Markdown

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -29,7 +29,7 @@ Keep abreast of IPFS team planning, management and coordination issues in the [I
 
 ## Blog
 
-Explore the latest news, events and other happenings in the IPFS multiverse on the official [https://ipfs.io/blog/](IPFS Blog).
+Explore the latest news, events and other happenings in the IPFS multiverse on the official [IPFS Blog](https://blog.ipfs.io/).
 
 ## IPFS YouTube channel
 


### PR DESCRIPTION
Problem: The Markdown link syntax is backward, which means that the link takes you to https://docs.ipfs.io/community/IPFS%20Blog.

Solution: Reverse the syntax and change the URL to blog.ipfs.io, which seems to be the new blog link.