### PR TITLE
Adds deprecation warning.

### DIFF
--- a/layouts/partials/betalink.html
+++ b/layouts/partials/betalink.html
@@ -1,6 +1,6 @@
 <div class="alert alert-beta">
   <div>
-    <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">🚀 Beta -> Launch</a></h4>
+    <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">🚀 New docs site coming May 15!</a></h4>
     <p>On May 15, this site will be replaced with the <a href="https://docs-beta.ipfs.io/">new IPFS docs website</a>. You can view this page on the <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">new site right now</a>!</p>
   </div>
   <div class="beta-icon">

--- a/layouts/partials/betalink.html
+++ b/layouts/partials/betalink.html
@@ -1,7 +1,7 @@
 <div class="alert alert-beta">
   <div>
     <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">🚀 New docs site coming May 15!</a></h4>
-    <p>On May 15, this site will be replaced with the <a href="https://docs-beta.ipfs.io/">new IPFS docs website</a>. You can view this page on the <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">new site right now</a>!</p>
+    <p>Heads up! On May 15, the legacy IPFS docs site will be deprecated and this page will be replaced by <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">its equivalent on the new docs site</a>. Pages will automatically redirect, </p> but you may wish to update your bookmarks or links after May 15.
   </div>
   <div class="beta-icon">
     <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}"><img src="/assets/thumbnail-beta-laptop.svg"></a>

--- a/layouts/partials/betalink.html
+++ b/layouts/partials/betalink.html
@@ -1,7 +1,7 @@
 <div class="alert alert-beta">
   <div>
     <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">🚀 New docs site coming May 15!</a></h4>
-    <p>Heads up! On May 15, the legacy IPFS docs site will be deprecated and this page will be replaced by <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">its equivalent on the new docs site</a>. Pages will automatically redirect, </p> but you may wish to update your bookmarks or links after May 15.
+    <p>Heads up! On May 15, the legacy IPFS docs site will be deprecated and this page will be replaced by <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">its equivalent on the new docs site</a>. Pages will automatically redirect,  but you may wish to update your bookmarks or links after May 15.
   </div>
   <div class="beta-icon">
     <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}"><img src="/assets/thumbnail-beta-laptop.svg"></a>

--- a/layouts/partials/betalink.html
+++ b/layouts/partials/betalink.html
@@ -1,8 +1,7 @@
 <div class="alert alert-beta">
   <div>
-    <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">View this page on the new IPFS Docs beta</a></h4>
-    <p>This content is now available at docs-beta.ipfs.io, a fully redesigned resource with search, reorganized content, and more.</p>
-    <p><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">Go&nbsp;></a></p>
+    <h4><a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">🚀 Beta -> Launch</a></h4>
+    <p>On May 15, this site will be replaced with the <a href="https://docs-beta.ipfs.io/">new IPFS docs website</a>. You can view this page on the <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}">new site right now</a>!</p>
   </div>
   <div class="beta-icon">
     <a href="https://docs-beta.ipfs.io/{{ $.Param "beta_equivalent" }}"><img src="/assets/thumbnail-beta-laptop.svg"></a>


### PR DESCRIPTION
Similar in style to the deprecation warning on the [docs-beta.ipfs.io site](https://docs-beta.ipfs.io).

![image](https://user-images.githubusercontent.com/9611008/81107883-daef6b00-8ee5-11ea-931c-9dbed9e9f2a6.png)

### [Preview here](https://bafybeicahkm4cnxkkudwquvharpb7pg5lzd3iqyk5lk5swt2fxwuqnhvim.ipfs.dweb.link/)

Closes ipfs/docs#501